### PR TITLE
Fix optional arrays/objects issue #771

### DIFF
--- a/client/src/utils/__tests__/schemaUtils.test.ts
+++ b/client/src/utils/__tests__/schemaUtils.test.ts
@@ -39,8 +39,8 @@ describe("generateDefaultValue", () => {
     ).toBe(false);
   });
 
-  test("generates default array", () => {
-    expect(generateDefaultValue({ type: "array" })).toEqual([]);
+  test("generates undefined for optional array", () => {
+    expect(generateDefaultValue({ type: "array" })).toBe(undefined);
   });
 
   test("generates default empty object", () => {
@@ -52,8 +52,18 @@ describe("generateDefaultValue", () => {
     expect(generateDefaultValue({ type: "unknown" })).toBe(undefined);
   });
 
-  test("generates empty array for non-required array", () => {
-    expect(generateDefaultValue({ type: "array" })).toEqual([]);
+  test("generates empty array for required array", () => {
+    const parentSchema = { required: ["testArray"] };
+    expect(
+      generateDefaultValue({ type: "array" }, "testArray", parentSchema),
+    ).toEqual([]);
+  });
+
+  test("generates undefined for non-required array", () => {
+    const parentSchema = { required: ["otherField"] };
+    expect(
+      generateDefaultValue({ type: "array" }, "testArray", parentSchema),
+    ).toBe(undefined);
   });
 
   test("generates empty object for non-required object", () => {

--- a/client/src/utils/__tests__/schemaUtils.test.ts
+++ b/client/src/utils/__tests__/schemaUtils.test.ts
@@ -43,8 +43,8 @@ describe("generateDefaultValue", () => {
     expect(generateDefaultValue({ type: "array" })).toBe(undefined);
   });
 
-  test("generates default empty object", () => {
-    expect(generateDefaultValue({ type: "object" })).toEqual({});
+  test("generates undefined for optional object", () => {
+    expect(generateDefaultValue({ type: "object" })).toBe(undefined);
   });
 
   test("generates default null for unknown types", () => {
@@ -66,8 +66,18 @@ describe("generateDefaultValue", () => {
     ).toBe(undefined);
   });
 
-  test("generates empty object for non-required object", () => {
-    expect(generateDefaultValue({ type: "object" })).toEqual({});
+  test("generates empty object for required object", () => {
+    const parentSchema = { required: ["testObject"] };
+    expect(
+      generateDefaultValue({ type: "object" }, "testObject", parentSchema),
+    ).toEqual({});
+  });
+
+  test("generates undefined for non-required object", () => {
+    const parentSchema = { required: ["otherField"] };
+    expect(
+      generateDefaultValue({ type: "object" }, "testObject", parentSchema),
+    ).toBe(undefined);
   });
 
   test("generates undefined for non-required primitive types", () => {

--- a/client/src/utils/schemaUtils.ts
+++ b/client/src/utils/schemaUtils.ts
@@ -109,7 +109,7 @@ export function generateDefaultValue(
     case "boolean":
       return isRequired ? false : undefined;
     case "array":
-      return [];
+      return isRequired ? [] : undefined;
     case "object": {
       if (!schema.properties) return {};
 

--- a/client/src/utils/schemaUtils.ts
+++ b/client/src/utils/schemaUtils.ts
@@ -111,7 +111,7 @@ export function generateDefaultValue(
     case "array":
       return isRequired ? [] : undefined;
     case "object": {
-      if (!schema.properties) return {};
+      if (!schema.properties) return isRequired ? {} : undefined;
 
       const obj: JsonObject = {};
       // Only include properties that are required according to the schema's required array
@@ -123,7 +123,7 @@ export function generateDefaultValue(
           }
         }
       });
-      return obj;
+      return isRequired ? obj : Object.keys(obj).length > 0 ? obj : undefined;
     }
     case "null":
       return null;


### PR DESCRIPTION
## Summary

Fixes MCP Inspector sending empty arrays `[]` and objects `{}` for optional parameters instead of omitting them, which causes compatibility issues with OpenAPI servers.

## Problem

- MCP Inspector was automatically sending empty arrays `[]` for optional array parameters
- MCP Inspector was automatically sending empty objects `{}` for optional object parameters  
- OpenAPI servers expect optional parameters to be completely absent when not specified
- This caused API calls to fail or behave unexpectedly

## Solution

Updated the `generateDefaultValue` function in `schemaUtils.ts` to:
- Return `undefined` for optional array parameters (omits them from requests)
- Return `undefined` for optional object parameters (omits them from requests)
- Continue returning `[]` for **required** array parameters
- Continue returning `{}` for **required** object parameters

## Implementation Plan

- [x] **Fix array handling**: Update array case to check if property is required, returning `[]` only for required arrays and `undefined` for optional arrays
- [x] **Fix object handling**: Update object case to check if property is required, returning `{}` only for required objects and `undefined` for optional objects
- [x] **Add comprehensive tests**: Ensure both required and non-required cases are tested for arrays and objects
- [x] **Verify consistency**: Make sure array and object behavior aligns with other optional types (string, number, boolean)
- [x] **Commit structure**: Create separate `fix:` commits for arrays and objects as requested

## Testing

Added comprehensive test coverage for:
- Optional arrays → `undefined` 
- Required arrays → `[]`
- Optional objects → `undefined`
- Required objects → `{}`
- Non-required arrays in parent schema → `undefined`
- Non-required objects in parent schema → `undefined`

All existing tests continue to pass, ensuring no regression.

## Expected Outcome

Optional array and object parameters will be omitted from tool call arguments instead of being sent as empty arrays/objects, resolving compatibility issues with OpenAPI servers.

Fixes #771